### PR TITLE
deploy.sh: remove jq dependency, misc fixes

### DIFF
--- a/aws/servicemesh/deploy.sh
+++ b/aws/servicemesh/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 shopt -s nullglob
 


### PR DESCRIPTION
There's no need to force the user to install `jq` as a prerequisite
to running the `deploy.sh` script, since the `aws` CLI can accept
JMESPath expressions via the `--query` option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
