### PR TITLE
deploy.sh: set shebang to bash

### DIFF
--- a/aws/cf/ecs-ec2/deploy.sh
+++ b/aws/cf/ecs-ec2/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 stacks=(
     "voteapp"


### PR DESCRIPTION
`deploy.sh` uses bash-isms like arrays; you can't assume `/bin/sh`
is bash (it might be dash on Ubuntu, for example).
