### PR TITLE
Remove task execution role from ec2 cfs

### DIFF
--- a/aws/cf/ecs-ec2/database.yml
+++ b/aws/cf/ecs-ec2/database.yml
@@ -75,9 +75,6 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'

--- a/aws/cf/ecs-ec2/queue.yml
+++ b/aws/cf/ecs-ec2/queue.yml
@@ -75,9 +75,6 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'

--- a/aws/cf/ecs-ec2/reports.yml
+++ b/aws/cf/ecs-ec2/reports.yml
@@ -70,9 +70,6 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2 
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'

--- a/aws/cf/ecs-ec2/voteapp.yml
+++ b/aws/cf/ecs-ec2/voteapp.yml
@@ -554,34 +554,6 @@ Resources:
               - 'elasticloadbalancing:RegisterTargets'
             Resource: '*'
 
-  # This is a role which is used by the ECS tasks themselves.
-  ECSTaskExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: [ecs-tasks.amazonaws.com]
-          Action: ['sts:AssumeRole']
-      Path: /
-      Policies:
-        - PolicyName: AmazonECSTaskExecutionRolePolicy
-          PolicyDocument:
-            Statement:
-            - Effect: Allow
-              Action:
-                # Allow the ECS Tasks to download images from ECR
-                - 'ecr:GetAuthorizationToken'
-                - 'ecr:BatchCheckLayerAvailability'
-                - 'ecr:GetDownloadUrlForLayer'
-                - 'ecr:BatchGetImage'
-
-                # Allow the ECS tasks to upload logs to CloudWatch
-                - 'logs:CreateLogStream'
-                - 'logs:PutLogEvents'
-              Resource: '*'
-
   # A role used by AWS Autoscaling to get the stats
   # service, and update it to increase or decrease the number of containers
   AutoscalingRole:
@@ -636,14 +608,9 @@ Outputs:
     Value: !GetAtt 'ECSRole.Arn'
     Export:
       Name: !Join [ ':', [ !Ref 'EnvironmentName', 'ECSRole' ] ]
-  ECSTaskExecutionRole:
-    Description: The ARN of the ECS role
-    Value: !GetAtt 'ECSTaskExecutionRole.Arn'
-    Export:
-      Name: !Join [ ':', [ !Ref 'EnvironmentName', 'ECSTaskExecutionRole' ] ]
   AutoscalingRole:
     Description: The ARN of the ECS role
-    Value: !GetAtt 'ECSTaskExecutionRole.Arn'
+    Value: !GetAtt 'ECSRole.Arn'
     Export:
       Name: !Join [ ':', [ !Ref 'EnvironmentName', 'AutoscalingRole' ] ]
   PublicListener:

--- a/aws/cf/ecs-ec2/votes.yml
+++ b/aws/cf/ecs-ec2/votes.yml
@@ -70,9 +70,6 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2 
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'

--- a/aws/cf/ecs-ec2/web.yml
+++ b/aws/cf/ecs-ec2/web.yml
@@ -70,9 +70,6 @@ Resources:
       NetworkMode: awsvpc
       RequiresCompatibilities:
         - EC2
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'

--- a/aws/cf/ecs-ec2/worker.yml
+++ b/aws/cf/ecs-ec2/worker.yml
@@ -69,10 +69,7 @@ Resources:
       Memory: !Ref 'TaskMemory'
       NetworkMode: awsvpc
       RequiresCompatibilities:
-        - EC2 
-      ExecutionRoleArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'EnvironmentName', 'ECSTaskExecutionRole']]
+        - EC2
       TaskRoleArn:
         Fn::If:
           - 'HasCustomRole'


### PR DESCRIPTION
Remove task execution role from ec2 cf since the instance role has the permissions

*Description of changes:*
Only Fargate needs the task execution role to call ecr/cw commands. EC2 already has the instance role. Removed it from all CF files. Made autoscaling role just be the ecsrole.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
