### PR TITLE
deploy.sh: fix bug in sanity_check

### DIFF
--- a/aws/cf/ecs-ec2/deploy.sh
+++ b/aws/cf/ecs-ec2/deploy.sh
@@ -16,7 +16,8 @@ stacks=(
 
 sanity_check() {
     if [ "$AWS_DEFAULT_REGION" != "us-west-2" ]; then
-        err "Only us-west-2 is supported at this time.  (Current default region: $AWS_DEFAULT_REGION)"
+        echo "Only us-west-2 is supported at this time.  (Current default region: $AWS_DEFAULT_REGION)" >&2
+        exit 1
     fi
 }
 


### PR DESCRIPTION
There's no `err` function in this script yet, so just bail out the
simplest way if the sanity check does not pass.