### PR TITLE
export AWS_DEFAULT_REGION

### DIFF
--- a/aws/cf/ecs-ec2/deploy.sh
+++ b/aws/cf/ecs-ec2/deploy.sh
@@ -3,6 +3,7 @@
 
 # Only us-west-2 is supported right now.
 : ${AWS_DEFAULT_REGION:=us-west-2}
+export AWS_DEFAULT_REGION
 
 stacks=(
     "voteapp"

--- a/aws/servicemesh/deploy.sh
+++ b/aws/servicemesh/deploy.sh
@@ -10,6 +10,7 @@ fi
 
 # Only us-west-2 is supported right now.
 : ${AWS_DEFAULT_REGION:=us-west-2}
+export AWS_DEFAULT_REGION
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 


### PR DESCRIPTION
The `AWS_DEFAULT_REGION` variable in the `deploy.sh` scripts needs
to be exported to work properly.