### PR TITLE
Fix queue url

### DIFF
--- a/aws/cf/ecs-ec2/queue.yml
+++ b/aws/cf/ecs-ec2/queue.yml
@@ -215,7 +215,7 @@ Outputs:
     Value:
       Fn::Join:
         - ''
-        - - 'http://'
+        - - ''
           - Fn::Join:
                 - '.'
                 - - 'queue'


### PR DESCRIPTION
the url for the queue has a http in it. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
