### PR TITLE
deploy.sh: Don't set a default AWS region

### DIFF
--- a/aws/cf/ecs-ec2/deploy.sh
+++ b/aws/cf/ecs-ec2/deploy.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # vim:syn=sh:ts=4:sw=4:et:ai
 
-# Only us-west-2 is supported right now.
-: ${AWS_DEFAULT_REGION:=us-west-2}
-
 stacks=(
      "voteapp"
 #     "database"

--- a/aws/servicemesh/deploy.sh
+++ b/aws/servicemesh/deploy.sh
@@ -8,9 +8,6 @@ if [ -f meshvars.sh ]; then
     source meshvars.sh
 fi
 
-# Only us-west-2 is supported right now.
-: ${AWS_DEFAULT_REGION:=us-west-2}
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 print() {
@@ -26,7 +23,7 @@ err() {
 
 sanity_check() {
     if [ "$AWS_DEFAULT_REGION" != "us-west-2" ]; then
-        err "Only us-west-2 is supported at this time.  (Current default region: $AWS_DEFAULT_REGION)"
+        err "Only us-west-2 is supported at this time. Ensure the AWS_DEFAULT_REGION environment variable is set to 'us-west-2' and try again. (Current default region: $AWS_DEFAULT_REGION)"
     fi
 }
 


### PR DESCRIPTION
If the current region is set to anything other than `us-west-2`, bail out of the setup scripts. 