### PR TITLE
Use the new UID spec for the envoy sidecar

### DIFF
--- a/samples/preview/apps/voteapp/ecs/ecs-voteapp.yaml
+++ b/samples/preview/apps/voteapp/ecs/ecs-voteapp.yaml
@@ -146,7 +146,7 @@ Resources:
             - Name: "APPMESH_VIRTUAL_NODE_NAME"
               Value: "reports-vn"
             - Name: "APPMESH_VIRTUAL_NODE_UID"
-              Value: { Ref: VoteReportsNodeId }
+              Value: "mesh/bookinfo/virtualNode/reports-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: { Ref: EnvoyLogLevel }
             - Name: "AWS_REGION"
@@ -284,7 +284,7 @@ Resources:
             - Name: "APPMESH_VIRTUAL_NODE_NAME"
               Value: "web-vn"
             - Name: "APPMESH_VIRTUAL_NODE_UID"
-              Value: { Ref: VoteWebNodeId }
+              Value: "mesh/bookinfo/virtualNode/web-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: { Ref: EnvoyLogLevel }
             - Name: "AWS_REGION"


### PR DESCRIPTION
### Description of changes

The latest app mesh update removes the need retain (or subsequently query) virtual node UIDs to supply as a parameter to the service tasks and simplify our deploy scripts.

We can now either just specify either the **virtual node resource** (ex: `mesh/bookinfo/virtualNode/details_node`) or **arn** (ex: `arn:aws:appmesh:us-west-2:733673854725:mesh/bookinfo/virtualNode/details_node`) for envoy task definitions.

So for example, the envoy task def for the **reports** virtual node would now look like this:

 Environment:
             - Name: "APPMESH_VIRTUAL_NODE_NAME"
              Value: "reports-vn"
            - Name: "APPMESH_VIRTUAL_NODE_UID"
              Value: mesh/bookinfo/virtualNode/reports-vn

And App Mesh will figure out actual UID for us.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
