### PR TITLE
Set x-envoy-decorator-operation in request headers

### DIFF
--- a/src/web/app.js
+++ b/src/web/app.js
@@ -25,8 +25,8 @@ let reportsAPI = axios.create({
     baseURL: reportsURI
 });
 
-captureAxios(votesAPI);
-captureAxios(reportsAPI);
+captureAxios(votesAPI, 'votes');
+captureAxios(reportsAPI, 'reports');
 
 // install route logging middleware
 app.use(morgan('dev'));
@@ -90,4 +90,3 @@ app.use(xrayExpress.closeSegment());
     process.exit(1);
   }
 })();
-

--- a/src/web/xray-axios.js
+++ b/src/web/xray-axios.js
@@ -1,7 +1,7 @@
 const xray = require('aws-xray-sdk-core');
 const segmentUtils = xray.SegmentUtils;
 
-let captureAxios = function(axios) {
+let captureAxios = function(axios, operation) {
 
   //add a request interceptor on POST
   axios.interceptors.request.use(function (config) {
@@ -11,7 +11,10 @@ let captureAxios = function(axios) {
 
     let root = parent.segment ? parent.segment : parent;
     let header = 'Root=' + root.trace_id + ';Parent=' + subsegment.id + ';Sampled=' + (!root.notTraced ? '1' : '0');
-    config.headers.post={ 'x-amzn-trace-id': header };
+    config.headers.post={
+      'x-amzn-trace-id': header,
+      'x-envoy-decorator-operation': operation
+    };
 
     xray.setSegment(subsegment);
 


### PR DESCRIPTION
Set the `x-envoy-decorator-operation` in the outbound request
header so that Envoy sets the `name` field to it when reporting
span tracing information to X-Ray.

