### PR TITLE
Adding xray to preview app

### DIFF
--- a/samples/preview/apps/voteapp/src/docker-compose.yaml
+++ b/samples/preview/apps/voteapp/src/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "2.1"
+
+networks:
+  bridge_net:
+    driver: bridge
+
+services:
+  reports:
+    build: reports
+    networks:
+      - bridge_net
+
+  web:
+    build: web
+    networks:
+      - bridge_net
+    ports:
+      - "3000:3000"

--- a/samples/preview/apps/voteapp/src/reports/package.json
+++ b/samples/preview/apps/voteapp/src/reports/package.json
@@ -16,6 +16,8 @@
     "node": ">=v8.0.0"
   },
   "dependencies": {
+    "aws-xray-sdk-core": "git+http://git@github.com/awssandra/aws-xray-node-sdk-core-experimental",
+    "aws-xray-sdk-express": "git+http://git@github.com/awssandra/aws-xray-node-sdk-express-experimental",
     "axios": "^0.18.0",
     "body-parser": "~1.18.3",
     "debug": "~4.1.0",

--- a/samples/preview/apps/voteapp/src/web/package.json
+++ b/samples/preview/apps/voteapp/src/web/package.json
@@ -16,6 +16,8 @@
     "node": ">=v8.0.0"
   },
   "dependencies": {
+    "aws-xray-sdk-core": "git+http://git@github.com/awssandra/aws-xray-node-sdk-core-experimental",
+    "aws-xray-sdk-express": "git+http://git@github.com/awssandra/aws-xray-node-sdk-express-experimental",
     "axios": "^0.18.0",
     "body-parser": "~1.18.3",
     "debug": "~4.1.0",

--- a/samples/preview/apps/voteapp/src/web/xray-axios.js
+++ b/samples/preview/apps/voteapp/src/web/xray-axios.js
@@ -1,0 +1,43 @@
+const xray = require('aws-xray-sdk-core');
+const segmentUtils = xray.SegmentUtils;
+
+let captureAxios = function(axios) {
+
+  //add a request interceptor on POST
+  axios.interceptors.request.use(function (config) {
+    var parent = xray.getSegment();
+    var subsegment = parent.addNewSubsegment(config.baseURL + config.url.substr(1));
+    subsegment.namespace = 'remote';
+
+    let root = parent.segment ? parent.segment : parent;
+    let header = 'Root=' + root.trace_id + ';Parent=' + subsegment.id + ';Sampled=' + (!root.notTraced ? '1' : '0');
+    config.headers.post={ 'x-amzn-trace-id': header };
+    config.headers.get={ 'x-amzn-trace-id': header };
+
+    xray.setSegment(subsegment);
+
+    return config;
+  }, function (error) {
+    var subsegment = xray.getSegment().addNewSubsegment("Intercept request error");
+    subsegment.close(error);
+
+    return Promise.reject(error);
+  });
+
+  // Add a response interceptor
+  axios.interceptors.response.use(function (response) {
+    var subsegment = xray.getSegment();
+    const res = { statusCode: response.status, headers: response.headers };
+
+    subsegment.addRemoteRequestData(response.request, res, true);
+    subsegment.close();
+    return response;
+  }, function (error) {
+    var subsegment = xray.getSegment();
+    subsegment.close(error);
+
+    return Promise.reject(error);
+  });
+};
+
+module.exports = captureAxios;


### PR DESCRIPTION
Adding this in the small chance the demo with X-Ray comes through.

This change ports X-Ray enabled work to preview app.
Also, fixes web /vote route to handle and return a response. We can fabricate a downstream service call in the x-ray data easily, and would only be a small change in order to do so (but not sure if we want to do that at this time).

Also adds docker-compose.yaml for easy testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
