### PR TITLE
Update Axios interceptor to inject tracing header on GET requests.

### DIFF
--- a/src/web/xray-axios.js
+++ b/src/web/xray-axios.js
@@ -11,6 +11,7 @@ let captureAxios = function(axios) {
 
     let root = parent.segment ? parent.segment : parent;
     let header = 'Root=' + root.trace_id + ';Parent=' + subsegment.id + ';Sampled=' + (!root.notTraced ? '1' : '0');
+    config.headers.get={ 'x-amzn-trace-id': header };
     config.headers.post={ 'x-amzn-trace-id': header };
 
     xray.setSegment(subsegment);


### PR DESCRIPTION
Axios requires separate configurations if not applying a static global value.
Since webapp does both GET to reportsapp and POST to votesapp, Axios needs a header defined for both.

This will propagate the trace ID correctly for both calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
