### PR TITLE
fixed deprecated k8s api endpoints

### DIFF
--- a/config/kubernetes/database-deployment.yml
+++ b/config/kubernetes/database-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: database-deployment

--- a/config/kubernetes/queue-deployment.yml
+++ b/config/kubernetes/queue-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-deployment

--- a/config/kubernetes/vote-deployment.yml
+++ b/config/kubernetes/vote-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote-deployment

--- a/config/kubernetes/worker-deployment.yml
+++ b/config/kubernetes/worker-deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker-deployment


### PR DESCRIPTION
**Issue #** (if available):

## Description of changes

`apps/v1beta1` endpoint is deprecated from Kubernetes 1.16 versoion. Fixed reference for deprecated api endpoint in manifest files.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

